### PR TITLE
fix(story-bar): 데스크탑 보기에서 가로 스크롤 안되는 현상 수정

### DIFF
--- a/js/story.js
+++ b/js/story.js
@@ -33,3 +33,29 @@ storyUsers.forEach((user) => {
 
   storyBar.appendChild(storyItem);
 });
+
+let isDown = false;
+let startX;
+let scrollLeft;
+
+storyBar.addEventListener("mousedown", (e) => {
+  isDown = true;
+  storyBar.classList.add("active");
+  startX = e.pageX - storyBar.offsetLeft;
+  scrollLeft = storyBar.scrollLeft;
+});
+storyBar.addEventListener("mouseleave", () => {
+  isDown = false;
+  storyBar.classList.remove("active");
+});
+storyBar.addEventListener("mouseup", () => {
+  isDown = false;
+  storyBar.classList.remove("active");
+});
+storyBar.addEventListener("mousemove", (e) => {
+  if (!isDown) return;
+  e.preventDefault();
+  const x = e.pageX - storyBar.offsetLeft;
+  const walk = (x - startX) * 1.5; // scroll speed
+  storyBar.scrollLeft = scrollLeft - walk;
+});


### PR DESCRIPTION
모바일은 터치 기반이기 때문에 overflow-x: auto가 적용된 요소는 손가락으로 자연스럽게 스와이프가 가능
데스크탑은 마우스 기반이기 때문에 가로 스크롤바를 직접 드래그하거나, 휠을 가로로 조작해야만 스크롤이 발생

드래그로 스크롤 가능하게 구현